### PR TITLE
Adding the missing dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,12 @@
             <version>1.1.5</version>
         </dependency>
 
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>glue</artifactId>
+            <version>2.17.52</version>
+        </dependency>
+
     </dependencies>
 
     <build>


### PR DESCRIPTION
*Issue #, if available:* [12](https://github.com/aws-samples/clickstream-producer-for-apache-kafka/issues/12)

*Description of changes:* Adding the glue SDK as dependency will resolve the Class not Found error explained in issue # 12


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
