### PR TITLE
Only create MM2 client for failover usage when using internal client logic for migrations

### DIFF
--- a/src/main/java/com/amazonaws/kafka/samples/ConsumerConfigs.java
+++ b/src/main/java/com/amazonaws/kafka/samples/ConsumerConfigs.java
@@ -31,7 +31,7 @@ class ConsumerConfigs {
     private static final String SSL_KEYSTORE_PASSWORD_CONFIG = "password";
     private static final String SSL_KEY_PASSWORD_CONFIG = "password";
     private static final String GROUP_ID_CONFIG = "mm2TestConsumer1";
-    private static final String METADATA_MAX_AGE_CONFIG = "5";
+    private static final String METADATA_MAX_AGE_CONFIG = "60000";
     private static final String CLIENT_ID_CONFIG = "clickstream-consumer";
     private static final String ENABLE_AUTO_COMMIT_CONFIG = "false";
     private static final String AUTO_OFFSET_RESET_CONFIG = "earliest";

--- a/src/main/java/com/amazonaws/kafka/samples/RunConsumer.java
+++ b/src/main/java/com/amazonaws/kafka/samples/RunConsumer.java
@@ -72,7 +72,7 @@ class RunConsumer implements Callable<String> {
 
                     currentOffsets.put(new TopicPartition(record.topic(), record.partition()), new OffsetAndMetadata(record.offset() + 1, "No Metadata"));
                 }
-                consumer.commitAsync(currentOffsets, null);
+                consumer.commitSync(currentOffsets);
             }
         } catch (WakeupException e) {
             // ignore for shutdown


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
